### PR TITLE
Troubleshoot barcode photo capture with Z3272PStdLib

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
@@ -8,12 +8,15 @@ namespace Z339xLib
     public static class Z339xLibSdk
     {
         // استدعاء الدوال من Z3272PStdLib.dll
-        [DllImport("Z3272PStdLib.dll", CallingConvention = CallingConvention.Cdecl)]
-        [return: MarshalAs(UnmanagedType.I1)]
-        private static extern bool GetImageAndSaveFile(string portName, string fileName, int format);
+        [DllImport("Z3272PStdLib.dll", EntryPoint = "GetImageAndSaveFile", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool Native_GetImageAndSaveFile(string portName, string fileName, int format);
 
-        [DllImport("Z3272PStdLib.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr GetImageByBitmap(string portName);
+        [DllImport("Z3272PStdLib.dll", EntryPoint = "GetImageByBitmap", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi, SetLastError = true)]
+        private static extern IntPtr Native_GetImageByBitmap(string portName);
+
+        [DllImport("gdi32.dll", SetLastError = true)]
+        private static extern bool DeleteObject(IntPtr hObject);
 
         /// <summary>
         /// يحفظ الصورة مباشرة بالمسار المطلوب
@@ -24,7 +27,7 @@ namespace Z339xLib
         /// <returns>True إذا نجحت العملية</returns>
         public static bool CaptureAndSave(string portName, string fileName, int format = 2)
         {
-            return GetImageAndSaveFile(portName, fileName, format);
+            return Native_GetImageAndSaveFile(portName, fileName, format);
         }
 
         /// <summary>
@@ -34,11 +37,13 @@ namespace Z339xLib
         /// <returns>Bitmap object أو null إذا صار خطأ</returns>
         public static Bitmap CaptureBitmap(string portName)
         {
-            IntPtr bmpPtr = GetImageByBitmap(portName);
+            IntPtr bmpPtr = Native_GetImageByBitmap(portName);
             if (bmpPtr == IntPtr.Zero)
                 return null;
 
             Bitmap bmp = Image.FromHbitmap(bmpPtr);
+            // Free unmanaged HBITMAP returned by the native DLL
+            DeleteObject(bmpPtr);
             return bmp;
         }
     }
@@ -52,7 +57,20 @@ class Program
     static void Main()
     {
         Console.WriteLine("🔌 Trying direct save with GetImageAndSaveFile...");
-        string savePath = @"C:\Temp\capture.jpg";
+        string saveDir = @"C:\\Temp";
+        string savePath = @"C:\\Temp\\capture.jpg";
+
+        try
+        {
+            if (!System.IO.Directory.Exists(saveDir))
+            {
+                System.IO.Directory.CreateDirectory(saveDir);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"⚠️ Cannot ensure save directory '{saveDir}': {ex.Message}");
+        }
 
         bool success = Z339xLib.Z339xLibSdk.CaptureAndSave("AUTO", savePath, 2); // JPEG
         if (success)
@@ -61,20 +79,7 @@ class Program
         }
         else
         {
-            Console.WriteLine("❌ Failed direct save. Trying GetImageByBitmap...");
-
-            Bitmap bmp = Z339xLib.Z339xLibSdk.CaptureBitmap("AUTO");
-            if (bmp != null)
-            {
-                string fallbackPath = @"C:\Temp\capture_fallback.jpg";
-                bmp.Save(fallbackPath, ImageFormat.Jpeg);
-                Console.WriteLine("✅ Captured via Bitmap: " + fallbackPath);
-                bmp.Dispose();
-            }
-            else
-            {
-                Console.WriteLine("❌ CaptureBitmap returned null");
-            }
+            Console.WriteLine("❌ Direct save failed.");
         }
     }
 }

--- a/c# test.csproj
+++ b/c# test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <Platforms>x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>

--- a/c# test.csproj
+++ b/c# test.csproj
@@ -1,19 +1,21 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <Platforms>x86</Platforms>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>c__test</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <EnableWindowsForms>true</EnableWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Z3272PStdLib.dll">
-        <HintPath>Z3272PStdLib.dll</HintPath>
-        <Private>true</Private>
-    </Reference>
+    <None Include="Z3272PStdLib.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Correct native DLL interop and project configuration to enable successful image capture from the barcode device.

The previous setup caused GDI+ errors when converting native HBITMAPs and "bad image" warnings from incorrect native DLL referencing. This PR updates P/Invoke signatures, frees native HBITMAPs, configures the project for x86 Windows, and exclusively uses the direct save function provided by the SDK to avoid these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-40ba0355-f319-4f57-96e6-db07091c5dff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40ba0355-f319-4f57-96e6-db07091c5dff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

